### PR TITLE
Sendgrid API no longer supports "marketing_campaigns" scope

### DIFF
--- a/tap_sendgrid/streams.py
+++ b/tap_sendgrid/streams.py
@@ -10,7 +10,8 @@ class Scopes(object):
     scopes = [
         'suppression.read',
         'asm.groups.read',
-        'marketing_campaigns.read',
+        'marketing.read',
+        'marketing.automation.read',
         'templates.read',
         'templates.versions.read'
     ]


### PR DESCRIPTION
# Description

Trying to configure this tap in Stitch yields the following error:

```
2019-08-28 18:21:05,094Z   main - INFO Tap exited abnormally with status 1
2019-08-28 18:21:05,096Z   main - INFO Exit status is: Discovery failed with code 1 and error message: "Insufficient authorization, missing for marketing_campaigns.read".
```

It appears that `marketing_campaigns.read` is no longer a supported permission for the Sendgrid API, which instead exposes `marketing.read` and `marketing.automation.read`. It is worth noting that the Sendgrid docs erroneously still list `marketing_campaings.read` as viable permission.

## Type of change

`marketing_campaigns.read` has been removed from `scopes` in `streams.py` and replaced with `marketing.read` and `marketing.automation.read`.