### PR TITLE
Revert "Sendgrid API no longer supports "marketing_campaigns" scope"

### DIFF
--- a/tap_sendgrid/streams.py
+++ b/tap_sendgrid/streams.py
@@ -10,8 +10,7 @@ class Scopes(object):
     scopes = [
         'suppression.read',
         'asm.groups.read',
-        'marketing.read',
-        'marketing.automation.read',
+        'marketing_campaigns.read',
         'templates.read',
         'templates.versions.read'
     ]


### PR DESCRIPTION
Reverts singer-io/tap-sendgrid#3