### PR TITLE
Add pytz as a dependency to resolve error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.0.4
+  * Add pytz to install_requires [#13](https://github.com/singer-io/tap-sendgrid/pull/13)
 
 ## 1.0.3
   * Reverts #3

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-sendgrid',
-      version='1.0.3',
+      version='1.0.4',
       description='Singer.io tap for extracting data from the SendGrid API',
       author='Stitch',
       url='http://singer.io',
@@ -12,6 +12,7 @@ setup(name='tap-sendgrid',
       install_requires=['singer-python==5.0.4',
                         'requests==2.20.0',
                         'pendulum==1.2.0',
+                        'pytz==2024.2',
                         ],
       entry_points='''
           [console_scripts]


### PR DESCRIPTION
# Description of change
Adds pytz as a dependency to resolve `tap - ModuleNotFoundError: No module named 'pytz'` error

# Manual QA steps
 - tested discovery gets past this error with a local connection
 
# Risks
 - low
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
